### PR TITLE
Add API key check and troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ A simple automated trading bot for Bitcoin built on the Alpaca API. It trains a 
    ```
 
 The model automatically retrains every few trades or once per day.
+
+## Troubleshooting
+
+A common issue when starting the bot is receiving a `403` error from the
+Alpaca API. This usually means the API keys are missing or invalid. Ensure that
+`ALPACA_API_KEY` and `ALPACA_SECRET_KEY` are correctly set in your environment
+before running the bot.

--- a/bitcoin_bot.py
+++ b/bitcoin_bot.py
@@ -29,6 +29,9 @@ MODEL_PATH = "ai_model.pkl"
 
 FEATURES = ["returns", "sma_3", "sma_6", "sma_15", "stddev", "vol_chg"]
 
+if not API_KEY or not SECRET_KEY:
+    raise RuntimeError("ALPACA_API_KEY and ALPACA_SECRET_KEY must be set")
+
 api = tradeapi.REST(API_KEY, SECRET_KEY, BASE_URL, api_version="v2")
 
 


### PR DESCRIPTION
## Summary
- check for Alpaca credentials before creating API client
- add guidance on common 403 errors in Troubleshooting section

## Testing
- `python -m py_compile bitcoin_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685c12a42ee4832fbf85e25fb86df98c